### PR TITLE
feat: add CI server to work asynchronously using daemon thread #39

### DIFF
--- a/src/server.py
+++ b/src/server.py
@@ -45,7 +45,7 @@ class CIServer:
         
         # Cleanup workspace
         self.pipeline.cleanup_workspace(workspace)
-
+        print("here")
         # Determine final status
         final_status = "Success" if tests_success else "Failure"
         send_email_notification(commit_id, author_email, final_status, "CI Process Completed.")


### PR DESCRIPTION
Updated the webhook handler to execute CI jobs asynchronously using a daemon thread. Extracted the CI execution logic into a separate function (run_ci) to improve readability. Ensured the CI thread does not block Flask’s shutdown process (daemon=True). Updated repo_url extraction to use data["repository"]["clone_url"] for consistency. Improved error handling for missing JSON fields with KeyError.