### PR TITLE
test: add two unit tests for the ci_pipeline file

### DIFF
--- a/src/ci_pipeline.py
+++ b/src/ci_pipeline.py
@@ -1,7 +1,7 @@
 # Main CI logic (compilation, testing)
 import ast
 import os
-from .logger import BuildLogger
+from logger import BuildLogger
 import git
 import subprocess
 import shutil

--- a/tests/test_ci_pipeline.py
+++ b/tests/test_ci_pipeline.py
@@ -26,6 +26,23 @@ class TestCIPipeline(unittest.TestCase):
         else:
             ci_pipeline.clone_pull_repo(repo_url, repo_dir)
             mock_clone.assert_called_with(repo_url, repo_dir)
+            
+            
+    def test_check_python_syntax_valid(self):
+        """
+        Test syntax checking with valid Python code.
+        """
+        # Setup
+        os.makedirs(self.test_repo_dir)
+        test_file = os.path.join(self.test_repo_dir, "test.py")
+        with open(test_file, 'w') as f:
+            f.write("def valid_function():\n    return True")
+
+        # Execute
+        result = self.pipeline.check_python_syntax(self.test_build_id, self.test_repo_dir)
+
+        # Assert
+        self.assertTrue(result)
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_ci_pipeline.py
+++ b/tests/test_ci_pipeline.py
@@ -27,31 +27,47 @@ class TestCIPipeline(unittest.TestCase):
         else:
             ci_pipeline.clone_pull_repo(repo_url, repo_dir)
             mock_clone.assert_called_with(repo_url, repo_dir)
-            
+    
+    
+    
+    def setUp(self):
+        """
+        Set up test environment before each test.
+        """
+        self.pipeline = ci_pipeline.CIPipeline()
+        self.test_build_id = "test_build"
+        self.test_repo_dir = "./test_syntax_repo"
+
+    def tearDown(self):
+        """
+        Clean up after each test.
+        """
+        if os.path.exists(self.test_repo_dir):
+            shutil.rmtree(self.test_repo_dir)
             
     def test_check_python_syntax_valid(self):
         """
         Test syntax checking with valid Python code.
         """
         
-        os.makedirs(self.repo_dir)
-        test_file = os.path.join(self.repo_dir, "test.py")
+        os.makedirs(self.test_repo_dir)
+        test_file = os.path.join(self.test_repo_dir, "test.py")
         with open(test_file, 'w') as f:
             f.write("def valid_function():\n    return True")
 
-        result = self.pipeline.check_python_syntax(self.test_build_id, self.repo_dir)
+        result = self.pipeline.check_python_syntax(self.test_build_id, self.test_repo_dir)
         self.assertTrue(result)
         
     def test_check_python_syntax_invalid(self):
         """
         Test syntax checking with invalid Python code.
         """
-        os.makedirs(self.repo_dir)
-        test_file = os.path.join(self.repo_dir, "test.py")
+        os.makedirs(self.test_repo_dir)
+        test_file = os.path.join(self.test_repo_dir, "test.py")
         with open(test_file, 'w') as f:
             f.write("def invalid_function():\n    return True:")
 
-        result = self.pipeline.check_python_syntax(self.test_build_id, self.repo_dir)
+        result = self.pipeline.check_python_syntax(self.test_build_id, self.test_repo_dir)
         self.assertFalse(result)
         
 

--- a/tests/test_ci_pipeline.py
+++ b/tests/test_ci_pipeline.py
@@ -3,6 +3,7 @@ import os
 import sys
 import subprocess
 import git
+import shutil
 from unittest.mock import patch
 # Update line below to match the file, function and variable names that are to be implemented
 # from file_name import clone_pull_function, repo_url, repo_dir
@@ -13,7 +14,7 @@ sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '../src'
 import ci_pipeline
 
 class TestCIPipeline(unittest.TestCase):
-
+    
     @patch("git.Repo.clone_from")
     @patch("git.Repo.git.pull")
     def test_repo(self, mock_pull, mock_clone):
@@ -32,17 +33,28 @@ class TestCIPipeline(unittest.TestCase):
         """
         Test syntax checking with valid Python code.
         """
-        # Setup
-        os.makedirs(self.test_repo_dir)
-        test_file = os.path.join(self.test_repo_dir, "test.py")
+        
+        os.makedirs(self.repo_dir)
+        test_file = os.path.join(self.repo_dir, "test.py")
         with open(test_file, 'w') as f:
             f.write("def valid_function():\n    return True")
 
-        # Execute
-        result = self.pipeline.check_python_syntax(self.test_build_id, self.test_repo_dir)
-
-        # Assert
+        result = self.pipeline.check_python_syntax(self.test_build_id, self.repo_dir)
         self.assertTrue(result)
+        
+    def test_check_python_syntax_invalid(self):
+        """
+        Test syntax checking with invalid Python code.
+        """
+        os.makedirs(self.repo_dir)
+        test_file = os.path.join(self.repo_dir, "test.py")
+        with open(test_file, 'w') as f:
+            f.write("def invalid_function():\n    return True:")
+
+        result = self.pipeline.check_python_syntax(self.test_build_id, self.repo_dir)
+        self.assertFalse(result)
+        
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Details: Add two tests for the Python syntax checking in the ci_pipeline file. The tests are:

- Assert True for valid Python code file input.
- Asserts False for invalid Python code file input.

Also adds setUp and tearDown functions for making temporary test dirs during testing. Python unit testing automatically runs the setUp before running unit tests and automatically runs tearDown after test completion, to avoid file clutter.

Relates to issue #33 and #53.