### PR TITLE
feat: Add an automated way of starting a ngrok server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ __pycache__/
 # Ignore system files
 .DS_Store  # macOS
 Thumbs.db  # Windows
+
+# Ignore config.json
+config.json

--- a/src/start_ngrok_server.py
+++ b/src/start_ngrok_server.py
@@ -1,0 +1,120 @@
+import os
+import sys
+import json
+import platform
+import textwrap
+import subprocess
+from pyngrok import ngrok
+from src.server import app  # Import the Flask "app" from server.py
+
+
+def start_ngrok_server():
+    """
+    Start a ngrok tunnel and Flask server based on configuration settings.
+
+    This function sets up a ngrok tunnel and starts a Flask application server. It retrieves hostname and port
+    from a JSON file located in the parent directory. The function
+    ensures proper cleanup of the ngrok process after termination.
+
+    The configuration file must be named 'config.json' and should reside in the
+    parent directory of the current file following this format:
+
+        {
+            "ngrok_hostname": "feasible-robin-vaguely.ngrok-free.app",
+            "port": 8004
+        }
+
+        Alternativly one can set the hostname to "random" to have ngrok choose one for you.
+
+        {
+            "ngrok_hostname": "random",
+            "port": 8004
+        }
+
+    Returns:
+        none
+
+    """
+
+    # Compute path to config.json in the parent directory
+    config_path = os.path.abspath(
+        os.path.join(os.path.dirname(__file__), "..", "config.json")
+    )
+
+    config_text_example = textwrap.dedent("""\
+        Create a file called config.json in the root of the project (not inside src/) that includes:
+            - ngrok_hostname (either a static domain or just the word "random" if you want ngrok to choose one for you)
+            - port
+                
+        Example 1: static domain
+        {
+            "ngrok_hostname": "feasible-robin-vaguely.ngrok-free.app",
+            "port": 8004
+        }
+        
+        Example 2: Let ngrok create a random domain for you:
+        {
+            "ngrok_hostname": "random",
+            "port": 8004
+        }
+        """)
+
+    # Attempt to parse the config file
+    try:
+        with open(config_path, "r") as config_file:
+            config = json.load(config_file)
+
+        hostname = config.get("ngrok_hostname")
+        port = config.get("port")
+
+        # Check it's correct
+        if not hostname or not port:
+            print("ERROR: The config.json file is missing 'ngrok_hostname' or 'port'.\n" + config_text_example)
+            sys.exit(1)
+    except:
+        print("ERROR: config.json is missing or invalid.\n" + config_text_example)
+        sys.exit(1)
+
+    tunnel = None
+    try:
+        # Start ngrok
+        if hostname == "random":
+            tunnel = ngrok.connect(addr=port)
+        else:
+            tunnel = ngrok.connect(addr=port, hostname=hostname)
+        print(f"ngrok tunnel established at: {tunnel.public_url}")
+
+        # Start flask server
+        app.run(port=port, use_reloader=False)
+
+    except KeyboardInterrupt:
+        print("Interrupted by user")
+    except Exception as e:
+        print(f"An error occurred: {e}")
+        sys.exit(1)
+    finally:
+        if tunnel is not None:
+            # Make sure ngrok dies, but if its dead just suppress the error
+            ngrok.kill()
+            os_name = platform.system()
+            try:
+                if os_name == "Windows":
+                    subprocess.run(
+                        ["taskkill", "/F", "/IM", "ngrok.exe"],
+                        check=True,
+                        stdout=subprocess.DEVNULL,
+                        stderr=subprocess.DEVNULL
+                    )
+                elif os_name in ["Linux", "Darwin"]:
+                    subprocess.run(
+                        ["pkill", "-f", "ngrok"],
+                        check=True,
+                        stdout=subprocess.DEVNULL,
+                        stderr=subprocess.DEVNULL
+                    )
+            except subprocess.CalledProcessError:
+                pass
+
+
+if __name__ == '__main__':
+    start_ngrok_server()

--- a/tests/test_ngrok_connection.py
+++ b/tests/test_ngrok_connection.py
@@ -1,48 +1,79 @@
 import os
 import sys
-import time
+import platform
 import unittest
 import requests
 import subprocess
 from pyngrok import ngrok
 
-NGROK_URL = "feasible-robin-vaguely.ngrok-free.app" 
-PORT = 8004 
 
 class TestNgrokIntegration(unittest.TestCase):
     """
     Example test suite that:
-      1) Starts ngrok tunnel on port 8004 in setUpClass
+      1) Launch start_ngrok_server.py in a subprocess
       2) Tests connectivity to the public ngrok URL
       3) Shuts down ngrok in tearDownClass
     """
-
-    @classmethod
-    def setUpClass(cls):
+    def setUp(self):
         """Start the Flask server and the ngrok tunnel."""
 
-        # Dynamically find the project root 
-        project_root = os.path.abspath(
-            os.path.join(os.path.dirname(__file__), '..')
-        )
-        
-        # Launch the Flask server with "-m src.server" so Python recognizes src/ as a package
-        cls.server_process = subprocess.Popen(
-            [sys.executable, "-m", "src.server"],
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            cwd=project_root  # set working directory to the project root
-        )
+        project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+        start_ngrok_server_path = os.path.join(project_root, "src", "start_ngrok_server.py")
 
-        cls.tunnel = ngrok.connect(
-            addr=PORT,
-            hostname=NGROK_URL,
-        )
+        self.server_process = None
+        self.public_url = None
 
-        cls.public_url = cls.tunnel.public_url
+        try:
+            self.server_process = subprocess.Popen(
+                [sys.executable, start_ngrok_server_path],
+                cwd=project_root,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                text=True
+            )
 
-        # Give ngrok a moment to fully start up
-        time.sleep(1)
+            # Wait for the server to come online
+            while True:
+                line = self.server_process.stdout.readline()
+
+                # If we didn't get a URL, raise an error
+                if not line and self.server_process.poll() is not None:
+                    raise RuntimeError("start_ngrok_server.py exited before providing a tunnel URL.")
+
+                print(line, end="")
+
+                # Look for a specific line that indicates the tunnel URL is established
+                # Example: "ngrok tunnel established at: http://feasible-robin-vaguely.ngrok-free.app"
+                if "ngrok tunnel established at:" in line:
+                    parts = line.split("ngrok tunnel established at: ")
+                    if len(parts) == 2:
+                        self.public_url = parts[1].strip()
+                        break
+
+            if not self.public_url:
+                raise RuntimeError("Failed to get the ngrok URL.")
+
+        except Exception as e:
+            if self.server_process:
+                self.server_process.terminate()
+            raise RuntimeError(f"Error during setUp: {str(e)}") from e
+
+    def tearDown(self):
+        """
+        Stop servers after tests.
+        """
+        if self.server_process:
+            self.server_process.terminate()
+            self.server_process.wait()
+            ngrok.kill()
+
+            os_name = platform.system()
+
+            if os_name == "Windows":
+                os.system("taskkill /F /IM ngrok.exe")
+            elif os_name in ["Linux", "Darwin"]:  # Darwin == macOS
+                subprocess.run(["pkill", "-f", "ngrok"], check=True)
+
 
     def test_get_root_endpoint(self):
         """
@@ -52,46 +83,18 @@ class TestNgrokIntegration(unittest.TestCase):
         url = f"{self.public_url}/"
         response = requests.get(url)
         self.assertEqual(
-            response.status_code, 
-            200, 
+            response.status_code,
+            200,
             f"Expected 200 OK from {url}, got {response.status_code}"
         )
 
-        # If your server returns text like "CI Server is running!",
-        # check it here:
+        # Check we get a confirmation message
         self.assertIn(
             "CI Server is running!",
             response.text,
             f"Expected 'CI Server is running!' in response, got {response.text}"
         )
 
-    def test_post_webhook_endpoint(self):
-        """
-        Test that the server's '/webhook' endpoint is accessible via ngrok,
-        receiving a JSON payload and returning a 200 with the expected response body.
-        """
-        url = f"{self.public_url}/webhook"
-        payload = {"test": "ngrok-connection"}
-        response = requests.post(url, json=payload)
-        self.assertEqual(
-            response.status_code, 
-            200, 
-            f"Expected 200 OK from {url}, got {response.status_code}"
-        )
-        
-        self.assertIn(
-            "Webhook received!",
-            response.text,
-            f"Expected 'Webhook received!' in response, got {response.text}"
-        )
-
-    @classmethod
-    def tearDownClass(cls):
-        """
-        Stop servers after tests.
-        """
-        ngrok.kill()
-        cls.server_process.terminate()
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Adds the file and function start_ngrok_server that starts a ngrok tunnel and the server. 
Test for that the server is running is also included.
Closes issue #40 

The user needs to have a config file (config.json) in the root of the project that specifies what hostname ngrok should use. They can also input "random" to make ngrok choose a random hostname. That hostname will also be printed in the terminal for easy access.

config.json example
Example 1: static domain
        {
            "ngrok_hostname": "feasible-robin-vaguely.ngrok-free.app",
            "port": 8004
        }
        
        Example 2: Let ngrok create a random domain for you:
        {
            "ngrok_hostname": "random",
            "port": 8004
        }

