### PR TITLE
fix: updated unit test for cloning repository

### DIFF
--- a/tests/test_ci_pipeline.py
+++ b/tests/test_ci_pipeline.py
@@ -8,35 +8,18 @@ from unittest.mock import patch
 # Update line below to match the file, function and variable names that are to be implemented
 # from file_name import clone_pull_function, repo_url, repo_dir
 repo_url = "https://github.com/willeStjerna/Group4_2"
-repo_dir = "./test_repo"
 
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '../src')))
 import ci_pipeline
 
 class TestCIPipeline(unittest.TestCase):
-    
-    @patch("git.Repo.clone_from")
-    @patch("git.Repo.git.pull")
-    def test_repo(self, mock_pull, mock_clone):
-        """
-        Test if the repository is cloned or pulled correctly.
-        """
-        if os.path.exists(repo_dir):
-            ci_pipeline.clone_pull_repo(repo_url, repo_dir)
-            mock_pull.assert_called()
-        else:
-            ci_pipeline.clone_pull_repo(repo_url, repo_dir)
-            mock_clone.assert_called_with(repo_url, repo_dir)
-    
-    
-    
     def setUp(self):
         """
         Set up test environment before each test.
         """
         self.pipeline = ci_pipeline.CIPipeline()
         self.test_build_id = "test_build"
-        self.test_repo_dir = "./test_syntax_repo"
+        self.test_repo_dir = "./test_repo"
 
     def tearDown(self):
         """
@@ -44,7 +27,42 @@ class TestCIPipeline(unittest.TestCase):
         """
         if os.path.exists(self.test_repo_dir):
             shutil.rmtree(self.test_repo_dir)
-            
+    
+    
+    @patch("git.Repo")
+    def test_clone_new_repository(self, mock_repo):
+        """
+        Test if the repository is cloned correctly when the directory doesn't exist.
+        """
+        mock_repo.clone_from.return_value = mock_repo
+        
+        result = self.pipeline.clone_pull_repo(repo_url, self.test_repo_dir)
+        
+        self.assertTrue(result)
+        mock_repo.clone_from.assert_called_once_with(
+            rep o_url, 
+            self.test_repo_dir, 
+            branch="main"
+        )
+
+    @patch("git.Repo")
+    def test_pull_existing_repository(self, mock_repo):
+        """
+        Test if the repository is pulled correctly when the directory exists.
+        """
+        os.makedirs(self.test_repo_dir)
+        mock_repo.return_value.heads = ["main"]
+        mock_instance = mock_repo.return_value
+        
+        result = self.pipeline.clone_pull_repo(repo_url, self.test_repo_dir)
+        
+        self.assertTrue(result)
+        mock_repo.clone_from.assert_not_called()
+        mock_instance.git.reset.assert_called_once_with("--hard")
+        mock_instance.git.clean.assert_called_once_with("-fd")
+        mock_instance.git.fetch.assert_called_once()
+        mock_instance.remotes.origin.pull.assert_called_once()
+
     def test_check_python_syntax_valid(self):
         """
         Test syntax checking with valid Python code.


### PR DESCRIPTION
Details: rewrote the unit test for repository cloning into two new tests:

1. Test if the function correctly clones the repository if none exists.

2. Tests if the function correctly clones the repository if there already exists one.

Also rewrote the function to correctly implement the setUp and tearDown functions in the test file.

Relates to issue #33.
Closes issue #60.