### PR TITLE
fix: use absolute imports consistently across the project.

### DIFF
--- a/src/ci_pipeline.py
+++ b/src/ci_pipeline.py
@@ -1,10 +1,10 @@
 # Main CI logic (compilation, testing)
 import ast
 import os
-from logger import BuildLogger
 import git
 import subprocess
 import shutil
+from src.logger import BuildLogger
 
 class CIPipeline:
     def __init__(self):

--- a/src/server.py
+++ b/src/server.py
@@ -3,9 +3,9 @@ import os
 import uuid
 from flask import Flask, request, jsonify
 from git import Repo
-from .ci_pipeline import CIPipeline
-from .notifications import send_email_notification
 import threading
+from src.ci_pipeline import CIPipeline
+from src.notifications import send_email_notification
 
 members = {
     "agussarsson": "arvid.gussarsson@gmail.com",

--- a/tests/test_ci_pipeline.py
+++ b/tests/test_ci_pipeline.py
@@ -5,19 +5,21 @@ import subprocess
 import git
 import shutil
 from unittest.mock import patch
+from src.ci_pipeline import CIPipeline
+
 # Update line below to match the file, function and variable names that are to be implemented
 # from file_name import clone_pull_function, repo_url, repo_dir
 repo_url = "https://github.com/willeStjerna/Group4_2"
 
-sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '../src')))
-import ci_pipeline
+#sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '../src')))
+
 
 class TestCIPipeline(unittest.TestCase):
     def setUp(self):
         """
         Set up test environment before each test.
         """
-        self.pipeline = ci_pipeline.CIPipeline()
+        self.pipeline = CIPipeline()
         self.test_build_id = "test_build"
         self.test_repo_dir = "./test_repo"
 

--- a/tests/test_github_api.py
+++ b/tests/test_github_api.py
@@ -3,18 +3,16 @@ import requests
 from unittest.mock import patch
 import sys
 import os
+from src.server import app
 
-
-sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '../src')))
-import server
 
 class TestGitHubAPI(unittest.TestCase):
     def setUp(self):
         """
         Create a simulated client for the CI server
         """
-        server.app.testing = True
-        self.client = server.app.sim_client()
+        app.testing = True
+        self.client = app.sim_client()
 
     def test_webhook_payload(self):
         """

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -3,9 +3,10 @@ from unittest.mock import patch
 import smtplib
 import sys
 import os
+from  src.notifications import send_email_notification
 
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '../src')))
-import notifications
+
 
 class TestNotifications(unittest.TestCase):
 
@@ -20,7 +21,7 @@ class TestNotifications(unittest.TestCase):
         dev_email = "some_dev@example.com"
         build_status = "Success"
         log_content = "abcabc"
-        notifications.send_email_notification(commit_id, dev_email, build_status, log_content)
+        send_email_notification(commit_id, dev_email, build_status, log_content)
 
         mock_server.sendmail.assert_called()
         mock_server.quit.assert_called()

--- a/tests/test_server_locally.py
+++ b/tests/test_server_locally.py
@@ -1,8 +1,7 @@
 import os
 import sys
 import unittest
-
-from src.server import app  # Import the Flask "app" from server.py
+from src.server import app
 
 class ServerConnectionTest(unittest.TestCase):
     """


### PR DESCRIPTION
Changes effected files so they use absolte path in the format:
`from src.my_file import my_function`

Now all files should be run in the root directory of the project (eg. Group4_2/) using
`python -m src.my_file`
Note: Notice lack of .py at the end of my_file

Resolves issue #51