### PR TITLE
test: add remaining unit tests for the functions in ci_pipeline.py

### DIFF
--- a/tests/test_ci_pipeline.py
+++ b/tests/test_ci_pipeline.py
@@ -90,6 +90,23 @@ class TestCIPipeline(unittest.TestCase):
         result = self.pipeline.check_python_syntax(self.test_build_id, self.test_repo_dir)
         self.assertFalse(result)
         
+    @patch('subprocess.run')
+    def test_run_tests_success(self, mock_run):
+        """
+        Test successful test execution with pytest.
+        """
+        os.makedirs(os.path.join(self.test_repo_dir, "tests"))
+        mock_run.return_value.returncode = 0
+        mock_run.return_value.stdout = "All tests passed"
+        
+        result = self.pipeline.run_tests(self.test_build_id, self.test_repo_dir)
+        
+        self.assertTrue(result)
+        mock_run.assert_called_once_with(
+            ["pytest", os.path.join(self.test_repo_dir, "tests")],
+            capture_output=True,
+            text=True
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_ci_pipeline.py
+++ b/tests/test_ci_pipeline.py
@@ -108,6 +108,17 @@ class TestCIPipeline(unittest.TestCase):
             text=True
         )
         
+    def test_run_tests_no_test_directory(self):
+        """
+        Test behavior when no tests directory exists.
+        """
+        os.makedirs(self.test_repo_dir)  # No tests dir
+        
+        result = self.pipeline.run_tests(self.test_build_id, self.test_repo_dir)
+        
+        self.assertTrue(result)  # No tests = no tests to fail = True
+
+        
     @patch('subprocess.run')
     def test_run_tests_failure(self, mock_run):
         """

--- a/tests/test_ci_pipeline.py
+++ b/tests/test_ci_pipeline.py
@@ -107,6 +107,19 @@ class TestCIPipeline(unittest.TestCase):
             capture_output=True,
             text=True
         )
+        
+    @patch('subprocess.run')
+    def test_run_tests_failure(self, mock_run):
+        """
+        Test failed test execution with pytest.
+        """
+        os.makedirs(os.path.join(self.test_repo_dir, "tests"))
+        mock_run.return_value.returncode = 1
+        mock_run.return_value.stdout = "Test failures occurred"
+        
+        result = self.pipeline.run_tests(self.test_build_id, self.test_repo_dir)
+        
+        self.assertFalse(result)
 
 
 if __name__ == "__main__":

--- a/tests/test_ci_pipeline.py
+++ b/tests/test_ci_pipeline.py
@@ -40,7 +40,7 @@ class TestCIPipeline(unittest.TestCase):
         
         self.assertTrue(result)
         mock_repo.clone_from.assert_called_once_with(
-            rep o_url, 
+            repo_url, 
             self.test_repo_dir, 
             branch="main"
         )


### PR DESCRIPTION
Details: Added the remaining unit tests for the ci_pipeline file. There are three new tests:

1. Assert that run_tests returns True for successful test execution.
2. Assert that run_tests returns False for unsuccessful test execution.
3. Assert that run_tests returns True for directories without a tests subdirectory, since there are no tests to run.

Closes issue #53 and #33.