### PR TITLE
doc: add module-level documentation and add html documentation files for each code file

### DIFF
--- a/docs/__init__.html
+++ b/docs/__init__.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN">
+<html><head><title>Python: module __init__</title>
+<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+</head><body bgcolor="#f0f0f8">
+
+<table width="100%" cellspacing=0 cellpadding=2 border=0 summary="heading">
+<tr bgcolor="#7799ee">
+<td valign=bottom>&nbsp;<br>
+<font color="#ffffff" face="helvetica, arial">&nbsp;<br><big><big><strong>__init__</strong></big></big></font></td
+><td align=right valign=bottom
+><font color="#ffffff" face="helvetica, arial"><a href=".">index</a><br><a href="file:/home/marcuserlandsson/School/DD2480_Softare_Dev_Intro/Group4_2/src/__init__.py">/home/marcuserlandsson/School/DD2480_Softare_Dev_Intro/Group4_2/src/__init__.py</a></font></td></tr></table>
+    <p><tt>#&nbsp;Makes&nbsp;src&nbsp;a&nbsp;Python&nbsp;package</tt></p>
+
+</body></html>

--- a/docs/config.html
+++ b/docs/config.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN">
+<html><head><title>Python: module config</title>
+<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+</head><body bgcolor="#f0f0f8">
+
+<table width="100%" cellspacing=0 cellpadding=2 border=0 summary="heading">
+<tr bgcolor="#7799ee">
+<td valign=bottom>&nbsp;<br>
+<font color="#ffffff" face="helvetica, arial">&nbsp;<br><big><big><strong>config</strong></big></big></font></td
+><td align=right valign=bottom
+><font color="#ffffff" face="helvetica, arial"><a href=".">index</a><br><a href="file:/home/marcuserlandsson/School/DD2480_Softare_Dev_Intro/Group4_2/src/config.py">/home/marcuserlandsson/School/DD2480_Softare_Dev_Intro/Group4_2/src/config.py</a></font></td></tr></table>
+    <p><tt>#&nbsp;Configuration&nbsp;settings</tt></p>
+
+</body></html>

--- a/docs/logger.html
+++ b/docs/logger.html
@@ -1,0 +1,76 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN">
+<html><head><title>Python: module logger</title>
+<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+</head><body bgcolor="#f0f0f8">
+
+<table width="100%" cellspacing=0 cellpadding=2 border=0 summary="heading">
+<tr bgcolor="#7799ee">
+<td valign=bottom>&nbsp;<br>
+<font color="#ffffff" face="helvetica, arial">&nbsp;<br><big><big><strong>logger</strong></big></big></font></td
+><td align=right valign=bottom
+><font color="#ffffff" face="helvetica, arial"><a href=".">index</a><br><a href="file:/home/marcuserlandsson/School/DD2480_Softare_Dev_Intro/Group4_2/src/logger.py">/home/marcuserlandsson/School/DD2480_Softare_Dev_Intro/Group4_2/src/logger.py</a></font></td></tr></table>
+    <p><tt>Build&nbsp;Logger&nbsp;Module<br>
+&nbsp;<br>
+This&nbsp;module&nbsp;provides&nbsp;logging&nbsp;functionality&nbsp;for&nbsp;CI&nbsp;build&nbsp;processes,<br>
+creating&nbsp;timestamped&nbsp;logs&nbsp;for&nbsp;each&nbsp;build&nbsp;stage&nbsp;in&nbsp;a&nbsp;dedicated&nbsp;log&nbsp;directory.<br>
+&nbsp;<br>
+Classes:<br>
+&nbsp;&nbsp;&nbsp;&nbsp;<a href="#BuildLogger">BuildLogger</a>:&nbsp;Handles&nbsp;logging&nbsp;of&nbsp;build&nbsp;events&nbsp;and&nbsp;results<br>
+&nbsp;<br>
+Functions:<br>
+&nbsp;&nbsp;&nbsp;&nbsp;None&nbsp;(all&nbsp;functionality&nbsp;is&nbsp;encapsulated&nbsp;in&nbsp;the&nbsp;<a href="#BuildLogger">BuildLogger</a>&nbsp;class)</tt></p>
+<p>
+<table width="100%" cellspacing=0 cellpadding=2 border=0 summary="section">
+<tr bgcolor="#aa55cc">
+<td colspan=3 valign=bottom>&nbsp;<br>
+<font color="#ffffff" face="helvetica, arial"><big><strong>Modules</strong></big></font></td></tr>
+    
+<tr><td bgcolor="#aa55cc"><tt>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</tt></td><td>&nbsp;</td>
+<td width="100%"><table width="100%" summary="list"><tr><td width="25%" valign=top><a href="os.html">os</a><br>
+</td><td width="25%" valign=top></td><td width="25%" valign=top></td><td width="25%" valign=top></td></tr></table></td></tr></table><p>
+<table width="100%" cellspacing=0 cellpadding=2 border=0 summary="section">
+<tr bgcolor="#ee77aa">
+<td colspan=3 valign=bottom>&nbsp;<br>
+<font color="#ffffff" face="helvetica, arial"><big><strong>Classes</strong></big></font></td></tr>
+    
+<tr><td bgcolor="#ee77aa"><tt>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</tt></td><td>&nbsp;</td>
+<td width="100%"><dl>
+<dt><font face="helvetica, arial"><a href="builtins.html#object">builtins.object</a>
+</font></dt><dd>
+<dl>
+<dt><font face="helvetica, arial"><a href="logger.html#BuildLogger">BuildLogger</a>
+</font></dt></dl>
+</dd>
+</dl>
+ <p>
+<table width="100%" cellspacing=0 cellpadding=2 border=0 summary="section">
+<tr bgcolor="#ffc8d8">
+<td colspan=3 valign=bottom>&nbsp;<br>
+<font color="#000000" face="helvetica, arial"><a name="BuildLogger">class <strong>BuildLogger</strong></a>(<a href="builtins.html#object">builtins.object</a>)</font></td></tr>
+    
+<tr bgcolor="#ffc8d8"><td rowspan=2><tt>&nbsp;&nbsp;&nbsp;</tt></td>
+<td colspan=2><tt><a href="#BuildLogger">BuildLogger</a>(log_dir='logs')<br>
+&nbsp;<br>
+<br>&nbsp;</tt></td></tr>
+<tr><td>&nbsp;</td>
+<td width="100%">Methods defined here:<br>
+<dl><dt><a name="BuildLogger-__init__"><strong>__init__</strong></a>(self, log_dir='logs')</dt><dd><tt>Initialize&nbsp;self.&nbsp;&nbsp;See&nbsp;help(type(self))&nbsp;for&nbsp;accurate&nbsp;signature.</tt></dd></dl>
+
+<dl><dt><a name="BuildLogger-log_build_result"><strong>log_build_result</strong></a>(self, build_id, stage, status, details)</dt><dd><tt>Log&nbsp;build&nbsp;results&nbsp;to&nbsp;a&nbsp;new&nbsp;file&nbsp;in&nbsp;the&nbsp;"logs"&nbsp;folder.<br>
+&nbsp;<br>
+Args:<br>
+&nbsp;&nbsp;&nbsp;&nbsp;build_id&nbsp;(str):&nbsp;Unique&nbsp;identifier&nbsp;for&nbsp;the&nbsp;build<br>
+&nbsp;&nbsp;&nbsp;&nbsp;stage&nbsp;(str):&nbsp;Pipeline&nbsp;stage&nbsp;(e.g.,&nbsp;'syntax_check',&nbsp;'tests')<br>
+&nbsp;&nbsp;&nbsp;&nbsp;status&nbsp;(str):&nbsp;Status&nbsp;of&nbsp;the&nbsp;stage&nbsp;('success',&nbsp;'failure')<br>
+&nbsp;&nbsp;&nbsp;&nbsp;details&nbsp;(str):&nbsp;Additional&nbsp;information&nbsp;about&nbsp;the&nbsp;stage&nbsp;result</tt></dd></dl>
+
+<hr>
+Data descriptors defined here:<br>
+<dl><dt><strong>__dict__</strong></dt>
+<dd><tt>dictionary&nbsp;for&nbsp;instance&nbsp;variables&nbsp;(if&nbsp;defined)</tt></dd>
+</dl>
+<dl><dt><strong>__weakref__</strong></dt>
+<dd><tt>list&nbsp;of&nbsp;weak&nbsp;references&nbsp;to&nbsp;the&nbsp;object&nbsp;(if&nbsp;defined)</tt></dd>
+</dl>
+</td></tr></table></td></tr></table>
+</body></html>

--- a/docs/notifications.html
+++ b/docs/notifications.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN">
+<html><head><title>Python: module notifications</title>
+<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+</head><body bgcolor="#f0f0f8">
+
+<table width="100%" cellspacing=0 cellpadding=2 border=0 summary="heading">
+<tr bgcolor="#7799ee">
+<td valign=bottom>&nbsp;<br>
+<font color="#ffffff" face="helvetica, arial">&nbsp;<br><big><big><strong>notifications</strong></big></big></font></td
+><td align=right valign=bottom
+><font color="#ffffff" face="helvetica, arial"><a href=".">index</a><br><a href="file:/home/marcuserlandsson/School/DD2480_Softare_Dev_Intro/Group4_2/src/notifications.py">/home/marcuserlandsson/School/DD2480_Softare_Dev_Intro/Group4_2/src/notifications.py</a></font></td></tr></table>
+    <p><tt>Notifications&nbsp;Module<br>
+&nbsp;<br>
+This&nbsp;module&nbsp;handles&nbsp;email&nbsp;notifications&nbsp;for&nbsp;CI&nbsp;build&nbsp;results,<br>
+supporting&nbsp;SMTP-based&nbsp;email&nbsp;delivery&nbsp;with&nbsp;configurable&nbsp;settings<br>
+loaded&nbsp;from&nbsp;environment&nbsp;variables.<br>
+&nbsp;<br>
+Functions:<br>
+&nbsp;&nbsp;&nbsp;&nbsp;send_email_notification:&nbsp;Sends&nbsp;build&nbsp;status&nbsp;notifications&nbsp;via&nbsp;email<br>
+&nbsp;<br>
+Environment&nbsp;Variables&nbsp;Required:<br>
+&nbsp;&nbsp;&nbsp;&nbsp;smtp_server:&nbsp;SMTP&nbsp;server&nbsp;hostname<br>
+&nbsp;&nbsp;&nbsp;&nbsp;smtp_sender:&nbsp;Sender&nbsp;email&nbsp;address<br>
+&nbsp;&nbsp;&nbsp;&nbsp;smtp_pwd:&nbsp;SMTP&nbsp;authentication&nbsp;password</tt></p>
+<p>
+<table width="100%" cellspacing=0 cellpadding=2 border=0 summary="section">
+<tr bgcolor="#aa55cc">
+<td colspan=3 valign=bottom>&nbsp;<br>
+<font color="#ffffff" face="helvetica, arial"><big><strong>Modules</strong></big></font></td></tr>
+    
+<tr><td bgcolor="#aa55cc"><tt>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</tt></td><td>&nbsp;</td>
+<td width="100%"><table width="100%" summary="list"><tr><td width="25%" valign=top><a href="logging.html">logging</a><br>
+</td><td width="25%" valign=top><a href="os.html">os</a><br>
+</td><td width="25%" valign=top><a href="smtplib.html">smtplib</a><br>
+</td><td width="25%" valign=top><a href="sys.html">sys</a><br>
+</td></tr></table></td></tr></table><p>
+<table width="100%" cellspacing=0 cellpadding=2 border=0 summary="section">
+<tr bgcolor="#eeaa77">
+<td colspan=3 valign=bottom>&nbsp;<br>
+<font color="#ffffff" face="helvetica, arial"><big><strong>Functions</strong></big></font></td></tr>
+    
+<tr><td bgcolor="#eeaa77"><tt>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</tt></td><td>&nbsp;</td>
+<td width="100%"><dl><dt><a name="-send_email_notification"><strong>send_email_notification</strong></a>(commit_id, receiver, build_status, log_output, user, branch)</dt><dd><tt>Sends&nbsp;an&nbsp;email&nbsp;notification&nbsp;about&nbsp;the&nbsp;CI&nbsp;build&nbsp;result.<br>
+&nbsp;<br>
+param&nbsp;commit_id&nbsp;(str):&nbsp;The&nbsp;Git&nbsp;commit&nbsp;hash&nbsp;being&nbsp;tested<br>
+param&nbsp;build_status&nbsp;(str):&nbsp;"Success"&nbsp;or&nbsp;"Failure"<br>
+param&nbsp;log_output&nbsp;(str):&nbsp;Log&nbsp;output&nbsp;from&nbsp;the&nbsp;build/test&nbsp;process</tt></dd></dl>
+</td></tr></table><p>
+<table width="100%" cellspacing=0 cellpadding=2 border=0 summary="section">
+<tr bgcolor="#55aa55">
+<td colspan=3 valign=bottom>&nbsp;<br>
+<font color="#ffffff" face="helvetica, arial"><big><strong>Data</strong></big></font></td></tr>
+    
+<tr><td bgcolor="#55aa55"><tt>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</tt></td><td>&nbsp;</td>
+<td width="100%"><strong>port</strong> = 587<br>
+<strong>pwd</strong> = None<br>
+<strong>sender</strong> = None<br>
+<strong>smtp_server</strong> = None</td></tr></table>
+</body></html>

--- a/src.html
+++ b/src.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN">
+<html><head><title>Python: package src</title>
+<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+</head><body bgcolor="#f0f0f8">
+
+<table width="100%" cellspacing=0 cellpadding=2 border=0 summary="heading">
+<tr bgcolor="#7799ee">
+<td valign=bottom>&nbsp;<br>
+<font color="#ffffff" face="helvetica, arial">&nbsp;<br><big><big><strong>src</strong></big></big></font></td
+><td align=right valign=bottom
+><font color="#ffffff" face="helvetica, arial"><a href=".">index</a><br><a href="file:/home/marcuserlandsson/School/DD2480_Softare_Dev_Intro/Group4_2/src/__init__.py">/home/marcuserlandsson/School/DD2480_Softare_Dev_Intro/Group4_2/src/__init__.py</a></font></td></tr></table>
+    <p><tt>#&nbsp;Makes&nbsp;src&nbsp;a&nbsp;Python&nbsp;package</tt></p>
+<p>
+<table width="100%" cellspacing=0 cellpadding=2 border=0 summary="section">
+<tr bgcolor="#aa55cc">
+<td colspan=3 valign=bottom>&nbsp;<br>
+<font color="#ffffff" face="helvetica, arial"><big><strong>Package Contents</strong></big></font></td></tr>
+    
+<tr><td bgcolor="#aa55cc"><tt>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</tt></td><td>&nbsp;</td>
+<td width="100%"><table width="100%" summary="list"><tr><td width="25%" valign=top><a href="src.ci_pipeline.html">ci_pipeline</a><br>
+<a href="src.config.html">config</a><br>
+</td><td width="25%" valign=top><a href="src.logger.html">logger</a><br>
+<a href="src.notifications.html">notifications</a><br>
+</td><td width="25%" valign=top><a href="src.server.html">server</a><br>
+<a href="src.start_ngrok_server.html">start_ngrok_server</a><br>
+</td><td width="25%" valign=top></td></tr></table></td></tr></table>
+</body></html>

--- a/src/ci_pipeline.py
+++ b/src/ci_pipeline.py
@@ -1,4 +1,15 @@
-# Main CI logic (compilation, testing)
+"""
+CI Pipeline Module
+
+This module contains the main continuous integration logic including repository
+management, syntax checking, and test execution functionality.
+
+Classes:
+    CIPipeline: Main CI logic (compilation, testing, syntax checking)
+    
+Functions:
+    None (all functionality is encapsulated in the CIPipeline class)
+"""
 import ast
 import os
 import git

--- a/src/logger.py
+++ b/src/logger.py
@@ -1,4 +1,15 @@
-# Logging utility
+"""
+Build Logger Module
+
+This module provides logging functionality for CI build processes,
+creating timestamped logs for each build stage in a dedicated log directory.
+
+Classes:
+    BuildLogger: Handles logging of build events and results
+
+Functions:
+    None (all functionality is encapsulated in the BuildLogger class)
+"""
 from datetime import datetime
 import os
 

--- a/src/notifications.py
+++ b/src/notifications.py
@@ -1,5 +1,18 @@
-# Email notifications
+"""
+Notifications Module
 
+This module handles email notifications for CI build results,
+supporting SMTP-based email delivery with configurable settings
+loaded from environment variables.
+
+Functions:
+    send_email_notification: Sends build status notifications via email
+
+Environment Variables Required:
+    smtp_server: SMTP server hostname
+    smtp_sender: Sender email address
+    smtp_pwd: SMTP authentication password
+"""
 import smtplib
 import os
 from email.mime.text import MIMEText

--- a/src/server.py
+++ b/src/server.py
@@ -1,4 +1,17 @@
-# Flask server to handle GitHub webhooks
+"""
+CI Server Module
+
+This module implements a Flask-based web server that handles GitHub webhooks
+and manages the CI pipeline execution. It processes incoming webhook events,
+triggers builds, and manages asynchronous CI operations.
+
+Classes:
+    CIServer: Manages CI workspace and build processes
+
+Functions:
+    index: Root endpoint that confirms server status
+    webhook: Handles GitHub webhook POST requests
+"""
 import os
 import uuid
 from flask import Flask, request, jsonify

--- a/src/start_ngrok_server.py
+++ b/src/start_ngrok_server.py
@@ -1,3 +1,18 @@
+"""
+Ngrok Server Module
+
+This module manages the setup and execution of an ngrok tunnel
+for exposing the local Flask server to the internet. It handles
+configuration loading, tunnel establishment, and process cleanup.
+
+Functions:
+    start_ngrok_server: Initializes and manages ngrok tunnel and Flask server
+
+Configuration:
+    Requires a config.json file in the project root with:
+    - ngrok_hostname: Static domain
+    - port: Port number for the server
+"""
 import os
 import sys
 import json


### PR DESCRIPTION
Details: Added documentation to the top of each code file, describing the module and listing all existing classes and functions within the file. Also added a new folder "docs" where I generated html files for each code file in src. The html files can be read as documentation in a browser by running a local pydoc server using "python3 -m pydoc -b" in the command line from the repository.

Closes issue #85.