### PR TITLE
fix: skip the ngrok test

### DIFF
--- a/tests/test_ngrok_connection.py
+++ b/tests/test_ngrok_connection.py
@@ -1,5 +1,6 @@
 import os
 import sys
+import pytest
 import platform
 import unittest
 import requests
@@ -7,6 +8,7 @@ import subprocess
 from pyngrok import ngrok
 
 
+@pytest.mark.skip(reason="Skipping ngrok test in CI environment")
 class TestNgrokIntegration(unittest.TestCase):
     """
     Example test suite that:


### PR DESCRIPTION
Because of the limitation of 1 ngrok connection per user we cant use our CI server to do that specific test.

Closes issue #93